### PR TITLE
Feature: PostTask input field and button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,11 +11,6 @@
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.

--- a/src/PostTask.tsx
+++ b/src/PostTask.tsx
@@ -1,0 +1,42 @@
+import { useState, ChangeEvent } from 'react';
+
+interface PostTaskProps {
+    onTaskAdded: () => void
+}
+
+export default function PostTask({ onTaskAdded }: PostTaskProps) {
+    const [inputTitle, setInputTitle] = useState<string>("");
+    const [addMessage, setAddMessage] = useState<string>("");
+
+    const handleAddChange = (e: ChangeEvent<HTMLInputElement>) => {
+        setInputTitle(e.target.value);
+    }
+
+    function handleAddClick(input: string) {
+        const url = "http://localhost:8080/tasks";
+
+        const data = {
+            Title: inputTitle,
+            Complete: false
+        };
+
+        fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(data)
+        })
+        .then(response => response.json())
+        .then(setAddMessage)
+        .then(onTaskAdded)
+    }
+
+    return (
+        <div>
+            <input value={inputTitle} onChange={handleAddChange}></input>
+            <button onClick={() => handleAddClick(inputTitle)}>Add Task</button>
+            <p>{addMessage}</p>
+        </div>
+    )
+}

--- a/src/TaskList.tsx
+++ b/src/TaskList.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Task } from './Task-Interface';
+import PostTask from './PostTask';
 
 const GET_TASKS_URL: string = "http://localhost:8080/tasks?id=&title=&complete="
 
@@ -20,8 +21,15 @@ export default function TaskList() {
         }
     }
 
+    function handleListChange() {
+        fetch(GET_TASKS_URL)
+        .then(response => response.json())
+        .then(setTaskList);
+    }
+
     return (
         <div>
+            <PostTask onTaskAdded={handleListChange} />
             <div>
                 {taskList.map(task => (
                 <p key={task.id}>#{task.id}: {task.title} - {handleComplete(task.complete)}</p>    


### PR DESCRIPTION
This branch adds an input field and button labeled "Add Task" to the application. A user can type the title of the task they'd like to add into the input field, then click on the button to add their task to the list. The ID of the new task sis automatically set (through the API), and the "complete" status of the task is currently hardcoded to false. A response message is displayed and the task list is updated when the button is clicked. To ensure this re-render, the PostTask component is called by TaskList instead of App and a handleListChange function was added.

![Screenshot 2023-07-06 at 3 31 14 PM](https://github.com/PeytonBoggs/todo-list-web/assets/129628668/e82cf963-b913-405a-8f0e-01c95709d5be)
