### PR TITLE
Feature: DeleteTask button

### DIFF
--- a/src/DeleteTask.tsx
+++ b/src/DeleteTask.tsx
@@ -1,0 +1,26 @@
+interface DeleteTaskProps {
+    onTaskDeleted: () => void
+    taskID: number
+}
+
+export default function DeleteTask({ onTaskDeleted, taskID }: DeleteTaskProps) {
+
+    function handleDeleteClick(id: number) {
+        const url = "http://localhost:8080/tasks/id/" + id
+
+        fetch(url, {
+            method: 'DELETE',
+            headers: {
+                'Content-Type': 'application/json'
+            }
+        })
+        .then(response => response.json())
+        .then(onTaskDeleted);
+    }
+
+    return (
+        <div>
+          <button onClick={() => handleDeleteClick(taskID)}>Delete</button>
+        </div>
+    );
+}

--- a/src/TaskList.tsx
+++ b/src/TaskList.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Task } from './Task-Interface';
 import PostTask from './PostTask';
+import DeleteTask from './DeleteTask';
 
 const GET_TASKS_URL: string = "http://localhost:8080/tasks?id=&title=&complete="
 
@@ -32,7 +33,10 @@ export default function TaskList() {
             <PostTask onTaskAdded={handleListChange} />
             <div>
                 {taskList.map(task => (
-                <p key={task.id}>#{task.id}: {task.title} - {handleComplete(task.complete)}</p>    
+                <div>
+                    <p key={task.id}>{task.title} - {handleComplete(task.complete)}</p>
+                    <DeleteTask onTaskDeleted={handleListChange} taskID={task.id}/>
+                </div>
                 ))}
             </div>
         </div>


### PR DESCRIPTION
This branch adds a delete button to each individual task. When pressed, the individual task is deleted from the database and removed from the display. IDs were also removed from the display since the API does not update the ID of all tasks when one is deleted - this might be fixed in a future update to the todo-list-API repo or an indexing function might be created in the react app. For now, tasks will solely display their name and completion status. 

https://github.com/PeytonBoggs/todo-list-web/assets/129628668/7965636f-ddbc-48fc-a234-7ffa0d5360df

